### PR TITLE
Change Plugin Method Names to `*_stackprofit_*`

### DIFF
--- a/lib/minitest/stackprofit_plugin.rb
+++ b/lib/minitest/stackprofit_plugin.rb
@@ -8,7 +8,7 @@ module Minitest
   @stackprof_path = nil
   @stackprof_type = :wall
 
-  def self.plugin_stackprof_options opts, options # :nodoc:
+  def self.plugin_stackprofit_options opts, options # :nodoc:
     opts.on "--stackprof [path]", String, "Save profiling to [path]." do |s|
       @stackprof_path = s || "stackprof.dump"
     end
@@ -18,7 +18,7 @@ module Minitest
     end
   end
 
-  def self.plugin_stackprof_init options # :nodoc:
+  def self.plugin_stackprofit_init options # :nodoc:
     if @stackprof_path then
       require "stackprof"
 


### PR DESCRIPTION
I found this gem through Google and thought it would save me time setting up `stackprof` on my test suite. I believe you need to change the names of the plubin methods to get it to work. Unfortunately, I wasn't able to test my branch, since I didn't want to add a gemspec, and I don't know how to use a gem that doesn't have a gemspec.

If I'm way off base or I shouldn't be submitting a PR, my apologies.